### PR TITLE
Replace Box for HTML Color input for color selector

### DIFF
--- a/src/Colors.js
+++ b/src/Colors.js
@@ -5,7 +5,17 @@ import Expander from './components/Expander';
 
 const getColor = (theme, name) => (
   theme.global.colors[name] !== undefined ? theme.global.colors[name]
-  : (grommet.global.colors[name] || base.global.colors[name]))
+    : (grommet.global.colors[name] || base.global.colors[name]))
+
+
+const ColorInput = ({ value, onChangeColor})=> (
+  <input
+    type="color"
+    value={value}
+    onChange={(event)=>{onChangeColor(event.target.value)}}
+  >
+  </input>
+)
 
 const ColorField = ({ theme, color, onChange }) => (
   <Field htmlFor={color} label={color}>
@@ -25,7 +35,14 @@ const ColorField = ({ theme, color, onChange }) => (
           onChange({ theme: nextTheme });
         }}
       />
-      <Box pad="small" background={getColor(theme, color)} />
+      <ColorInput
+        value={getColor(theme, color)}
+        onChangeColor={(colorVal)=>{
+          const nextTheme = JSON.parse(JSON.stringify(theme));
+          nextTheme.global.colors[color] = colorVal;
+          onChange({ theme: nextTheme });
+        }}
+      ></ColorInput>
     </Box>
   </Field>
 )


### PR DESCRIPTION
**Request summary**

Add:
- HTML 'color' input for designer's color selectors. This enables designers to select from the full-color input spectrum additionally to inputting a "pre-defined" HEX string

Remove:
- 'Box' element representing the current color. This is now represented by the HTML color input's value

#OpenSource #Hacktoberfest